### PR TITLE
feat: await incoming requests on a stable public quintus sh domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ calendar.
 
 ## Changes
 
-- feat: serve incoming time requests with configured cloud computing 2024-09-25
+- feat: await incoming requests on a stable public quintus sh domain 2024-09-26
+- feat: serve incoming time requests with configured cloud computing 2024-09-26
 - ci: confirm changes are made to the changelog before merges happen 2024-09-17
 - ci: confirm udp ntp requests for timings pass testing with success 2024-09-17
 - feat: serve ntp times over udp connections using the gregorian utc 2024-09-16

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🗓️ quintus
 
-> a five day calendar
+> five day calendar
 
 ## Counting the weeks to make a month
 
@@ -25,9 +25,9 @@ Part of this project is dedicated to serving the true times in computer format
 with the [Network Time Protocol][ntp]:
 
 ```sh
-$ sntp 3.84.149.188
+$ sntp quintus.sh
 ...
-2024-09-21 22:08:36.024433 (+0700) -0.988038 +/- 0.658707 3.84.149.188 s1 no-leap
+2024-09-22 16:24:11.756589 (+0700) -0.719544 +/- 0.479711 quintus.sh 3.84.124.11 s1 no-leap
 ```
 
 > 🚧 While other setup happens, this program aligns with a Gregorian calendar.

--- a/tullius/domains.tf
+++ b/tullius/domains.tf
@@ -2,3 +2,13 @@
 resource "aws_route53_zone" "timekeeper" {
   name = var.domain
 }
+
+# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/route53_record
+resource "aws_route53_record" "servius" {
+  name    = var.domain
+  type    = "A"
+  zone_id = aws_route53_zone.timekeeper.id
+  ttl     = 300
+
+  records = [aws_instance.clock.public_ip]
+}

--- a/tullius/ec2.tf
+++ b/tullius/ec2.tf
@@ -15,5 +15,5 @@ resource "aws_ami" "cicero" {
 resource "aws_instance" "clock" {
   ami                    = aws_ami.cicero.id
   instance_type          = "t3.nano"
-  vpc_security_group_ids = [aws_security_group.hourglass.name]
+  vpc_security_group_ids = [aws_security_group.hourglass.id]
 }

--- a/tullius/outputs.tf
+++ b/tullius/outputs.tf
@@ -2,6 +2,10 @@ output "public_dns" {
   value = aws_instance.clock.public_dns
 }
 
+output "public_domain" {
+  value = var.domain
+}
+
 output "public_ip" {
   value = aws_instance.clock.public_ip
 }


### PR DESCRIPTION
**[quintus.sh](quintus.sh)** is now listening on port `123`