### PR TITLE
fix!: start the new year during nil period but align month january

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ calendar.
 
 ## Changes
 
+- fix!: start the new year during nil period but align month january 2024-11-15
 - fix: open the http port for web access without using a certificate 2024-10-12
 - feat: write the current time and comparison to a webpage on domain 2024-09-28
 - fix!: follow the quintus calendar when handling the time protocols 2024-09-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ calendar.
 
 ## Changes
 
-- fix!: start the new year during nil period but align month january 2024-11-15
+- fix!: start the new year during nil period but align month january 2024-11-30
 - fix: open the http port for web access without using a certificate 2024-10-12
 - feat: write the current time and comparison to a webpage on domain 2024-09-28
 - fix!: follow the quintus calendar when handling the time protocols 2024-09-26

--- a/cicero/pkg/now/now.go
+++ b/cicero/pkg/now/now.go
@@ -17,7 +17,7 @@ type Now struct {
 
 // Moment realizes the provided utc time in the standard quintus format
 func Moment(utc time.Time) Now {
-	return Now{
+	now := Now{
 		year:   utc.Year(),
 		month:  utc.YearDay() / 30,
 		date:   utc.YearDay() % 30,
@@ -25,6 +25,14 @@ func Moment(utc time.Time) Now {
 		minute: utc.Minute(),
 		second: utc.Second(),
 	}
+	switch now.month {
+	case 12:
+		now.month = 0
+		now.year += 1
+	default:
+		now.month += 1
+	}
+	return now
 }
 
 // Epoch represents the number of seconds since the Unix epoch for the current
@@ -34,17 +42,17 @@ func Moment(utc time.Time) Now {
 // Dates that the Gregorian calendar cannot show are waited for on the previous
 // date until the next possible date arrives
 func (n *Now) Epoch() uint64 {
-	var month time.Month
-	var date int
-	if n.month != 12 {
-		month = time.Month(n.month + 1)
-		date = n.date
-	} else {
+	year := n.year
+	month := time.Month(n.month)
+	date := n.date
+	switch n.month {
+	case 0:
+		year = n.year - 1
 		month = time.Month(12)
 		date = 31
 	}
 	conversion := time.Date(
-		n.year,
+		year,
 		month,
 		date,
 		n.hour,
@@ -70,7 +78,7 @@ func (n Now) ToString() string {
 	return fmt.Sprintf(
 		"%d-%02d-%02dT%02d:%02d:%02dZ",
 		n.year,
-		n.month+1,
+		n.month,
 		n.date,
 		n.hour,
 		n.minute,

--- a/cicero/pkg/now/now_test.go
+++ b/cicero/pkg/now/now_test.go
@@ -23,14 +23,24 @@ func TestMoment(t *testing.T) {
 			expected: "1970-02-01T00:00:00Z",
 			epoch:    time.Date(1970, 2, 1, 0, 0, 0, 0, time.UTC).Unix(),
 		},
+		"append the trailing nil period to the beginning of the year": {
+			now:      time.Date(1999, 12, 27, 0, 0, 0, 0, time.UTC),
+			expected: "2000-00-01T00:00:00Z",
+			epoch:    time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"wait to start the next year with a nil period for resetting": {
+			now:      time.Date(1999, 12, 31, 23, 59, 59, 99, time.UTC),
+			expected: "2000-00-05T23:59:59Z",
+			epoch:    time.Date(1999, 12, 31, 23, 59, 59, 99, time.UTC).Unix(),
+		},
 		"capture additions of a leap year increasing counting offsets": {
 			now:      time.Date(2000, 12, 31, 23, 59, 59, 99, time.UTC),
-			expected: "2000-13-06T23:59:59Z",
+			expected: "2001-00-06T23:59:59Z",
 			epoch:    time.Date(2000, 12, 31, 23, 59, 59, 99, time.UTC).Unix(),
 		},
 		"confirm that leap years are counted using the correct offset": {
 			now:      time.Date(2100, 12, 31, 23, 59, 59, 99, time.UTC),
-			expected: "2100-13-05T23:59:59Z",
+			expected: "2101-00-05T23:59:59Z",
 			epoch:    time.Date(2100, 12, 31, 23, 59, 59, 99, time.UTC).Unix(),
 		},
 		"find impossible dates repeat the date before if this happens": {


### PR DESCRIPTION
this pr moves the "nil" period at the end of one year to the start of the next. sorting is preserved and counting from zero makes things a bit easier.

it's perhaps confusing since the next numeric year starts earlier, but this should be a time of recharge anyways...