### PR TITLE
fix!: keep a matching leap year when converting the current moment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ calendar.
 
 ## Changes
 
+- fix!: keep a matching leap year when converting the current moment 2024-12-02
 - fix!: start the new year during nil period but align month january 2024-11-30
 - fix: open the http port for web access without using a certificate 2024-10-12
 - feat: write the current time and comparison to a webpage on domain 2024-09-28

--- a/cicero/main_test.go
+++ b/cicero/main_test.go
@@ -29,6 +29,6 @@ func TestCicero(t *testing.T) {
 	response, err := ntpclient.Time("localhost:12321")
 	require.NoError(t, err)
 	wait := now.Sub(response)
-	assert.Greater(t, int64(0), wait.Milliseconds())
-	assert.LessOrEqual(t, wait.Milliseconds()%10000, int64(1200))
+	assert.Greater(t, wait.Milliseconds(), int64(0))
+	assert.LessOrEqual(t, wait.Milliseconds(), int64(1200))
 }

--- a/cicero/pkg/iso/iso.go
+++ b/cicero/pkg/iso/iso.go
@@ -1,0 +1,10 @@
+package iso
+
+import (
+	"time"
+)
+
+// Leaps decides if a year has a leap day
+func Leaps(year int) bool {
+	return 365 < time.Date(year, time.December, 31, 0, 0, 0, 0, time.UTC).YearDay()
+}

--- a/cicero/pkg/iso/iso_test.go
+++ b/cicero/pkg/iso/iso_test.go
@@ -1,0 +1,49 @@
+package iso
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLeaps(t *testing.T) {
+	tests := map[string]struct {
+		year     int
+		expected bool
+	}{
+		"2000 leaps": {
+			year:     2000,
+			expected: true,
+		},
+		"2001 hops": {
+			year:     2001,
+			expected: false,
+		},
+		"2002 hops": {
+			year:     2002,
+			expected: false,
+		},
+		"2004 leaps": {
+			year:     2004,
+			expected: true,
+		},
+		"2100 hops": {
+			year:     2100,
+			expected: false,
+		},
+		"2200 hops": {
+			year:     2200,
+			expected: false,
+		},
+		"2400 leaps": {
+			year:     2400,
+			expected: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := Leaps(tt.year)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/cicero/pkg/now/now.go
+++ b/cicero/pkg/now/now.go
@@ -97,3 +97,8 @@ func (n Now) ToString() string {
 		n.second,
 	)
 }
+
+// Year returns the year
+func (n Now) Year() int {
+	return n.year
+}

--- a/cicero/pkg/now/now.go
+++ b/cicero/pkg/now/now.go
@@ -3,6 +3,8 @@ package now
 import (
 	"fmt"
 	"time"
+
+	"github.com/zimeg/quintus/cicero/pkg/iso"
 )
 
 // Now is this moment
@@ -17,10 +19,14 @@ type Now struct {
 
 // Moment realizes the provided utc time in the standard quintus format
 func Moment(utc time.Time) Now {
+	offset := utc.YearDay() - 1
+	if iso.Leaps(utc.Year()) {
+		offset -= 1
+	}
 	now := Now{
 		year:   utc.Year(),
-		month:  utc.YearDay() / 30,
-		date:   utc.YearDay() % 30,
+		month:  (offset / 30),
+		date:   (offset % 30) + 1,
 		hour:   utc.Hour(),
 		minute: utc.Minute(),
 		second: utc.Second(),
@@ -29,6 +35,12 @@ func Moment(utc time.Time) Now {
 	case 12:
 		now.month = 0
 		now.year += 1
+	case 0:
+		if iso.Leaps(now.year) && now.date == 0 {
+			now.date = 6
+			break
+		}
+		fallthrough
 	default:
 		now.month += 1
 	}
@@ -41,7 +53,7 @@ func Moment(utc time.Time) Now {
 //
 // Dates that the Gregorian calendar cannot show are waited for on the previous
 // date until the next possible date arrives
-func (n *Now) Epoch() uint64 {
+func (n Now) Epoch() uint64 {
 	year := n.year
 	month := time.Month(n.month)
 	date := n.date
@@ -69,7 +81,7 @@ func (n *Now) Epoch() uint64 {
 
 // Offset adds the seconds since the NTP epoch 1900-01-01 00:00:00 to the valid
 // Unix epoch of now
-func (n *Now) Offset() uint64 {
+func (n Now) Offset() uint64 {
 	return uint64(2208988800+n.Epoch()) << 32
 }
 

--- a/cicero/pkg/now/now_test.go
+++ b/cicero/pkg/now/now_test.go
@@ -23,35 +23,95 @@ func TestMoment(t *testing.T) {
 			expected: "1970-02-01T00:00:00Z",
 			epoch:    time.Date(1970, 2, 1, 0, 0, 0, 0, time.UTC).Unix(),
 		},
-		"append the trailing nil period to the beginning of the year": {
+		"preserve the end of some current year before next leap year": {
+			now:      time.Date(1999, 12, 26, 0, 0, 0, 0, time.UTC),
+			expected: "1999-12-30T00:00:00Z",
+			epoch:    time.Date(1999, 12, 30, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"append a trailing nil period to the beginning of next year": {
 			now:      time.Date(1999, 12, 27, 0, 0, 0, 0, time.UTC),
 			expected: "2000-00-01T00:00:00Z",
 			epoch:    time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC).Unix(),
 		},
-		"wait to start the next year with a nil period for resetting": {
+		"increment the nil period according to sensible step counts": {
+			now:      time.Date(1999, 12, 28, 0, 0, 0, 0, time.UTC),
+			expected: "2000-00-02T00:00:00Z",
+			epoch:    time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"match the expected nil period of with normal amount prior": {
 			now:      time.Date(1999, 12, 31, 23, 59, 59, 99, time.UTC),
 			expected: "2000-00-05T23:59:59Z",
 			epoch:    time.Date(1999, 12, 31, 23, 59, 59, 99, time.UTC).Unix(),
 		},
-		"capture additions of a leap year increasing counting offsets": {
+		"continue some year with a leaping nil period before start": {
+			now:      time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: "2000-00-06T00:00:00Z",
+			epoch:    time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"begin the starts that leap in a mismatching step fashion": {
+			now:      time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC),
+			expected: "2000-01-01T00:00:00Z",
+			epoch:    time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"find tomorrow is a single more than whatever started before": {
+			now:      time.Date(2000, 1, 3, 0, 0, 0, 0, time.UTC),
+			expected: "2000-01-02T00:00:00Z",
+			epoch:    time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"explore an extra sunrise of the second month keeps aligned": {
+			now:      time.Date(2000, 2, 29, 0, 0, 0, 0, time.UTC),
+			expected: "2000-02-29T00:00:00Z",
+			epoch:    time.Date(2000, 2, 29, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"watch that extra sunrise has a noon without strange offset": {
+			now:      time.Date(2000, 2, 29, 12, 34, 56, 789, time.UTC),
+			expected: "2000-02-29T12:34:56Z",
+			epoch:    time.Date(2000, 2, 29, 12, 34, 56, 789, time.UTC).Unix(),
+		},
+		"ideas of march repeat what a groundhog sees in cast shadow": {
+			now:      time.Date(2000, 3, 1, 0, 0, 0, 0, time.UTC),
+			expected: "2000-02-30T00:00:00Z",
+			epoch:    time.Date(2000, 2, 29, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"end a leap year on the expected end date with offsettings": {
+			now:      time.Date(2000, 12, 26, 0, 0, 0, 0, time.UTC),
+			expected: "2000-12-30T00:00:00Z",
+			epoch:    time.Date(2000, 12, 30, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"start a next year the correct amount of offset expected days": {
+			now:      time.Date(2000, 12, 27, 0, 0, 0, 0, time.UTC),
+			expected: "2001-00-01T00:00:00Z",
+			epoch:    time.Date(2000, 12, 31, 0, 0, 0, 0, time.UTC).Unix(),
+		},
+		"confirm leap days are kept with expected leap year offsets": {
 			now:      time.Date(2000, 12, 31, 23, 59, 59, 99, time.UTC),
-			expected: "2001-00-06T23:59:59Z",
+			expected: "2001-00-05T23:59:59Z",
 			epoch:    time.Date(2000, 12, 31, 23, 59, 59, 99, time.UTC).Unix(),
 		},
-		"confirm that leap years are counted using the correct offset": {
-			now:      time.Date(2100, 12, 31, 23, 59, 59, 99, time.UTC),
-			expected: "2101-00-05T23:59:59Z",
-			epoch:    time.Date(2100, 12, 31, 23, 59, 59, 99, time.UTC).Unix(),
+		"starting a standard count after leaps begins with schedule": {
+			now:      time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: "2001-01-01T00:00:00Z",
+			epoch:    time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
 		},
 		"find impossible dates repeat the date before if this happens": {
 			now:      time.Date(2001, 2, 28, 0, 0, 0, 0, time.UTC),
 			expected: "2001-02-29T00:00:00Z",
 			epoch:    time.Date(2001, 2, 28, 0, 0, 0, 0, time.UTC).Unix(),
 		},
+		"keep counting up on an irregular shortened month a marches": {
+			now:      time.Date(2001, 3, 1, 0, 0, 0, 0, time.UTC),
+			expected: "2001-02-30T00:00:00Z",
+			epoch:    time.Date(2001, 2, 28, 0, 0, 0, 0, time.UTC).Unix(),
+		},
 		"check a known date around the time of development to be sure": {
 			now:      time.Date(2024, 9, 21, 10, 26, 8, 5, time.UTC),
-			expected: "2024-09-25T10:26:08Z",
-			epoch:    time.Date(2024, 9, 25, 10, 26, 8, 5, time.UTC).Unix(),
+			expected: "2024-09-24T10:26:08Z",
+			epoch:    time.Date(2024, 9, 24, 10, 26, 8, 5, time.UTC).Unix(),
+		},
+		"confirm that leap years are counted using the correct offset": {
+			now:      time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: "2100-01-01T00:00:00Z",
+			epoch:    time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
 		},
 	}
 	for name, tt := range tests {

--- a/cicero/pkg/tcp/routes/index.go
+++ b/cicero/pkg/tcp/routes/index.go
@@ -14,7 +14,7 @@ import (
 func Index(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, "%d-04-04T03:55:05Z", time.Now().Year())
+		fmt.Fprintf(w, "%d-04-04T03:55:05Z", now.Moment(time.Now().UTC()).Year())
 		return
 	}
 	tpl := `


### PR DESCRIPTION
this unmatches "jan 1" on leap years but keeps all 366 days in years with extra