### PR TITLE
test: compare the returned quintus epoch from current moments time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ calendar.
 
 ## Changes
 
+- test: compare the returned quintus epoch from current momemnt time 2025-06-01
 - build: package dependencies before tullius setups as configuration 2025-05-26
 - feat: print quintus dates in a calendar matching related gregorian 2025-05-26
 - fix!: keep a matching leap year when converting the current moment 2024-12-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ calendar.
 
 ## Changes
 
-- test: compare the returned quintus epoch from current momemnt time 2025-06-01
+- test: compare the returned quintus epoch from current moments time 2025-06-01
 - build: package dependencies before tullius setups as configuration 2025-05-26
 - feat: print quintus dates in a calendar matching related gregorian 2025-05-26
 - fix!: keep a matching leap year when converting the current moment 2024-12-02

--- a/cicero/main_test.go
+++ b/cicero/main_test.go
@@ -7,6 +7,7 @@ import (
 	ntpclient "github.com/beevik/ntp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zimeg/quintus/cicero/pkg/now"
 	"github.com/zimeg/quintus/cicero/pkg/udp"
 )
 
@@ -25,10 +26,9 @@ func TestCicero(t *testing.T) {
 		require.NoError(t, err)
 		respond(conn, addr, buff)
 	}()
-	now := time.Now()
 	response, err := ntpclient.Time("localhost:12321")
 	require.NoError(t, err)
-	wait := now.Sub(response)
-	assert.Greater(t, wait.Milliseconds(), int64(0))
-	assert.LessOrEqual(t, wait.Milliseconds(), int64(1200))
+	wait := now.Moment(time.Now().UTC()).Epoch() - uint64(response.Unix())
+	assert.GreaterOrEqual(t, wait, uint64(0))
+	assert.LessOrEqual(t, wait, uint64(1200))
 }


### PR DESCRIPTION
🤐wrong date check oops