### PR TITLE
build: replace additional providers from infrastructure registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ calendar.
 
 ## Changes
 
+- build: replace additional providers from infrastructure registries 2025-10-07
 - chore: update the license year at the turn of the quintus calendar 2025-06-01
 - feat: scroll back into the past or toward future dates in infinite 2025-06-01
 - test: compare the returned quintus epoch from current moments time 2025-06-01

--- a/tullius/.terraform.lock.hcl
+++ b/tullius/.terraform.lock.hcl
@@ -1,7 +1,7 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.opentofu.org/opentofu/aws" {
+provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.66.0"
   constraints = "5.66.0"
   hashes = [

--- a/tullius/acm.tf
+++ b/tullius/acm.tf
@@ -1,4 +1,4 @@
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/acm_certificate
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/acm_certificate
 resource "aws_acm_certificate" "cert" {
   domain_name       = var.domain
   validation_method = "DNS"
@@ -8,7 +8,7 @@ resource "aws_acm_certificate" "cert" {
   }
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/route53_record
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/route53_record
 resource "aws_route53_record" "default_records" {
   for_each = {
     for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {

--- a/tullius/domains.tf
+++ b/tullius/domains.tf
@@ -1,9 +1,9 @@
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/route53_zone
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/route53_zone
 resource "aws_route53_zone" "timekeeper" {
   name = var.domain
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/route53_record
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/route53_record
 resource "aws_route53_record" "servius" {
   name    = var.domain
   type    = "A"

--- a/tullius/ebs.tf
+++ b/tullius/ebs.tf
@@ -1,4 +1,4 @@
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/ebs_snapshot_import
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/ebs_snapshot_import
 resource "aws_ebs_snapshot_import" "cicero" {
   role_name = aws_iam_role.vm.id
 

--- a/tullius/ec2.tf
+++ b/tullius/ec2.tf
@@ -1,4 +1,4 @@
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/ami
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/ami
 resource "aws_ami" "cicero" {
   name                = "ciceroami"
   virtualization_type = "hvm"
@@ -11,7 +11,7 @@ resource "aws_ami" "cicero" {
   }
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/instance
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/instance
 resource "aws_instance" "clock" {
   ami                    = aws_ami.cicero.id
   instance_type          = "t3.nano"

--- a/tullius/iam.tf
+++ b/tullius/iam.tf
@@ -1,10 +1,10 @@
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/iam_role_policy_attachment
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment
 resource "aws_iam_role_policy_attachment" "vm" {
   role       = aws_iam_role.vm.id
   policy_arn = aws_iam_policy.vm.arn
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/iam_role
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/iam_role
 resource "aws_iam_role" "vm" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -23,7 +23,7 @@ resource "aws_iam_role" "vm" {
   })
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/iam_role_policy
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/iam_role_policy
 resource "aws_iam_policy" "vm" {
   policy = jsonencode({
     Version = "2012-10-17"

--- a/tullius/main.tf
+++ b/tullius/main.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = "1.9.1"
 
   required_providers {
-    # https://search.opentofu.org/provider/opentofu/aws/latest
+    # https://search.opentofu.org/provider/hashicorp/aws/latest
     aws = {
-      source  = "opentofu/aws"
+      source  = "hashicorp/aws"
       version = "5.66.0"
     }
   }

--- a/tullius/s3.tf
+++ b/tullius/s3.tf
@@ -1,9 +1,9 @@
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/datasources/s3_bucket
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/datasources/s3_bucket
 resource "aws_s3_bucket" "server" {
   bucket = var.vhs
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/s3_bucket_ownership_controls
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls
 resource "aws_s3_bucket_ownership_controls" "vhs" {
   bucket = aws_s3_bucket.server.id
 
@@ -12,7 +12,7 @@ resource "aws_s3_bucket_ownership_controls" "vhs" {
   }
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/s3_bucket_public_access_block
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block
 resource "aws_s3_bucket_public_access_block" "lock" {
   bucket = aws_s3_bucket.server.id
 
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_public_access_block" "lock" {
   restrict_public_buckets = true
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/datasources/s3_object
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/datasources/s3_object
 resource "aws_s3_object" "upload" {
   bucket = aws_s3_bucket.server.id
   key    = "cicero.vhd"

--- a/tullius/security.tf
+++ b/tullius/security.tf
@@ -1,9 +1,9 @@
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/security_group
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/security_group
 resource "aws_security_group" "hourglass" {
   name = "qt.hourglass"
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/vpc_security_group_egress_rule
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule
 resource "aws_vpc_security_group_egress_rule" "outbound" {
   security_group_id = aws_security_group.hourglass.id
 
@@ -11,7 +11,7 @@ resource "aws_vpc_security_group_egress_rule" "outbound" {
   ip_protocol = "-1"
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/vpc_security_group_ingress_rule
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule
 resource "aws_vpc_security_group_ingress_rule" "http" {
   security_group_id = aws_security_group.hourglass.id
 
@@ -21,7 +21,7 @@ resource "aws_vpc_security_group_ingress_rule" "http" {
   to_port     = 80
 }
 
-# https://search.opentofu.org/provider/opentofu/aws/latest/docs/resources/vpc_security_group_ingress_rule
+# https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule
 resource "aws_vpc_security_group_ingress_rule" "ntp" {
   security_group_id = aws_security_group.hourglass.id
 


### PR DESCRIPTION
🤖 

```
╷
│ Warning: Additional provider information from registry
│
│ The remote registry returned warnings for registry.opentofu.org/opentofu/aws:
│ - You are using opentofu/aws instead of hashicorp/aws. This provider is maintained by HashiCorp and the
│ OpenTofu project only builds the provider binaries from the source code. Both the opentofu/ and
│ hashicorp/ namespaces in the OpenTofu Registry contain the OpenTofu-built provider binaries based on
│ the HashiCorp source code. To avoid configuration errors, we recommend using the hashicorp/ namespaced
│ providers.
╵
```